### PR TITLE
Fixing spelling mistake

### DIFF
--- a/src/resources/DB/skillsDB.js
+++ b/src/resources/DB/skillsDB.js
@@ -74,7 +74,7 @@ const skills = [
     {   
         id: 9,
         logo: 'devicon-bootstrap-plain',
-        name:'Bootsrapp',
+        name:'Bootstrap',
         level:'Comfortable'
     },
     {


### PR DESCRIPTION
Changing the name value for the object inside the skills array from "Bootsrapp" to "Bootstrap"